### PR TITLE
Use MemoryRouter to enable rendering of components with Links

### DIFF
--- a/frontend/src/components/feed/Feed.cy.js
+++ b/frontend/src/components/feed/Feed.cy.js
@@ -1,10 +1,11 @@
+import { MemoryRouter } from 'react-router'
 import Feed from './Feed'
 const navigate = () => {}
 
 describe("Feed", () => {
   it("Calls the /posts endpoint and lists all the posts", () => {
     window.localStorage.setItem("token", "fakeToken")
-    
+
     cy.intercept('GET', '/posts', (req) => {
         req.reply({
           statusCode: 200,
@@ -16,8 +17,12 @@ describe("Feed", () => {
       }
     ).as("getPosts")
 
-    cy.mount(<Feed navigate={navigate}/>)
-    
+    cy.mount(
+      <MemoryRouter>
+        <Feed navigate={navigate}/>
+      </MemoryRouter>
+    )
+
     cy.wait("@getPosts").then(() =>{
       cy.get('[data-cy="post"]')
       .should('contain.text', "Hello, world")

--- a/frontend/src/components/post/Post.cy.js
+++ b/frontend/src/components/post/Post.cy.js
@@ -1,8 +1,13 @@
+import { MemoryRouter } from 'react-router';
 import Post from './Post'
 
 describe("Post", () => {
   it('renders a post with a message', () => {
-    cy.mount(<Post post={{_id: 1, message: "Hello, world"}} />);
+    cy.mount(
+      <MemoryRouter>
+        <Post post={{_id: 1, message: "Hello, world"}} />
+      </MemoryRouter>
+    );
     cy.get('[data-cy="post"]').should('contain.text', "Hello, world")
   })
 })


### PR DESCRIPTION
When you're testing a component it might have a Link component in it.

This Link component will fail (with an error to do with useHref) if it isn't
rendered within a router of some kind.

You can use MemoryRouter as a lightweight router in your tests to achieve this.

If you wanted an alternative, you might mock out the Link component.
